### PR TITLE
Fix thread safety of interpretations list

### DIFF
--- a/auparse/auparse-idata.h
+++ b/auparse/auparse-idata.h
@@ -40,11 +40,12 @@ typedef struct _idata {
 
 
 int auparse_interp_adjust_type(int rtype, const char *name, const char *val);
-char *auparse_do_interpretation(int type, const idata *id,
-	auparse_esc_t escape_mode);
-void _auparse_load_interpretations(const char *buf);
-void _auparse_free_interpretations(void);
-const char *_auparse_lookup_interpretation(const char *name);
+char *auparse_do_interpretation(auparse_state_t *au, int type,
+       const idata *id, auparse_esc_t escape_mode);
+void _auparse_load_interpretations(auparse_state_t *au, const char *buf);
+void _auparse_free_interpretations(auparse_state_t *au);
+const char *_auparse_lookup_interpretation(auparse_state_t *au,
+       const char *name);
 void _auparse_flush_caches(void);
 
 #endif

--- a/auparse/auparse.c
+++ b/auparse/auparse.c
@@ -49,7 +49,7 @@ static time_t	eoe_timeout = EOE_TIMEOUT;
 static void init_lib(void) __attribute__ ((constructor));
 static void init_lib(void)
 {
-	init_interpretation_list();
+       /* interpretation list is now part of auparse_state_t */
 }
 
 /* like strchr except string is delimited by length, not null byte */
@@ -633,8 +633,8 @@ static void consume_feed(auparse_state_t *au, int flush)
 			au->le = l;  // make this current the event of interest
 			aup_list_first(l);
 			r = aup_list_get_cur(l);
-			free_interpretation_list();
-			load_interpretation_list(r->interp);
+                       free_interpretation_list(au);
+                       load_interpretation_list(au, r->interp);
 			aup_list_first_field(l);
 
 			if (au->callback) {
@@ -722,22 +722,22 @@ void auparse_set_escape_mode(auparse_state_t *au, auparse_esc_t mode)
  * buf is a string of name value pairs to be used for interpreting.
  * Calling this function automatically releases the previous list.
  */
-void _auparse_load_interpretations(const char *buf)
+void _auparse_load_interpretations(auparse_state_t *au, const char *buf)
 {
-	free_interpretation_list();
+       free_interpretation_list(au);
 
 	if (buf == NULL)
 		return;
 
-	load_interpretation_list(buf);
+       load_interpretation_list(au, buf);
 }
 
 /*
  * Non-public function. Subject to change.
  */
-void _auparse_free_interpretations(void)
+void _auparse_free_interpretations(auparse_state_t *au)
 {
-	free_interpretation_list();
+       free_interpretation_list(au);
 }
 
 int auparse_reset(auparse_state_t *au)
@@ -782,7 +782,7 @@ int auparse_reset(auparse_state_t *au)
 		default:
 			return -1;
 	}
-	free_interpretation_list();
+       free_interpretation_list((auparse_state_t *)au);
 	return 0;
 }
 
@@ -1038,7 +1038,7 @@ static void auparse_destroy_common(auparse_state_t *au)
 		fclose(au->in);
 		au->in = NULL;
 	}
-	free_interpretation_list();
+       free_interpretation_list(au);
 	clear_normalizer(&au->norm_data);
 	au_lol_clear(au->au_lo, 0);
 	free((void *)au->tmp_translation);
@@ -1551,8 +1551,8 @@ static int au_auparse_next_event(auparse_state_t *au)
 
 		aup_list_first(l);
 		r = aup_list_get_cur(l);
-		free_interpretation_list();
-		load_interpretation_list(r->interp);
+               free_interpretation_list(au);
+               load_interpretation_list(au, r->interp);
 		aup_list_first_field(l);
 		au->le = l;
 #ifdef	LOL_EVENTS_DEBUG01
@@ -1603,8 +1603,8 @@ static int au_auparse_next_event(auparse_state_t *au)
 
 				aup_list_first(l);
 				r = aup_list_get_cur(l);
-				free_interpretation_list();
-				load_interpretation_list(r->interp);
+                               free_interpretation_list(au);
+                               load_interpretation_list(au, r->interp);
 				aup_list_first_field(l);
 				au->le = l;
 #ifdef	LOL_EVENTS_DEBUG01
@@ -1707,8 +1707,8 @@ static int au_auparse_next_event(auparse_state_t *au)
 
 			aup_list_first(l);
 			r = aup_list_get_cur(l);
-			free_interpretation_list();
-			load_interpretation_list(r->interp);
+                       free_interpretation_list(au);
+                       load_interpretation_list(au, r->interp);
 			aup_list_first_field(l);
 			au->le = l;
 #ifdef	LOL_EVENTS_DEBUG01
@@ -1851,8 +1851,8 @@ int auparse_first_record(auparse_state_t *au)
 	}
 	aup_list_first(au->le);
 	r = aup_list_get_cur(au->le);
-	free_interpretation_list();
-	load_interpretation_list(r->interp);
+       free_interpretation_list(au);
+       load_interpretation_list(au, r->interp);
 	aup_list_first_field(au->le);
 
 	return 1;
@@ -1867,7 +1867,7 @@ int auparse_next_record(auparse_state_t *au)
 {
 	rnode *r;
 
-	free_interpretation_list();
+       free_interpretation_list(au);
 	// Its OK if au->le == NULL because get_cnt handles it
 	if (aup_list_get_cnt(au->le) == 0) {
 		int rc = auparse_first_record(au);
@@ -1876,7 +1876,7 @@ int auparse_next_record(auparse_state_t *au)
 	}
 	r = aup_list_next(au->le);
 	if (r) {
-		load_interpretation_list(r->interp);
+               load_interpretation_list(au, r->interp);
 		return 1;
 	} else
 		return 0;
@@ -1897,14 +1897,14 @@ int auparse_goto_record_num(const auparse_state_t *au, unsigned int num)
 	}
 
 	/* Check if a request is out of range */
-	free_interpretation_list();
+       free_interpretation_list(au);
 	// Its OK if au->le == NULL because get_cnt handles it
 	if (num >= aup_list_get_cnt(au->le))
 		return 0;
 
 	r = aup_list_goto_rec(au->le, num);
 	if (r != NULL) {
-		load_interpretation_list(r->interp);
+               load_interpretation_list(au, r->interp);
 		aup_list_first_field(au->le);
 		return 1;
 	} else
@@ -2089,8 +2089,8 @@ const char *auparse_find_field_next(const auparse_state_t *au)
 			r = aup_list_next(au->le);
 			if (r) {
 				aup_list_first_field(au->le);
-				free_interpretation_list();
-				load_interpretation_list(r->interp);
+                               free_interpretation_list(au);
+                               load_interpretation_list(au, r->interp);
 			}
 		}
 	}
@@ -2193,7 +2193,7 @@ const char *auparse_interpret_field(auparse_state_t *au)
 		rnode *r = aup_list_get_cur(au->le);
 		if (r) {
 			r->cwd = NULL;
-			return nvlist_interp_cur_val(r, au->escape_mode);
+                       return nvlist_interp_cur_val(au, r, au->escape_mode);
 		}
 	}
 	return NULL;
@@ -2213,7 +2213,8 @@ const char *auparse_interpret_realpath(const auparse_state_t *au)
 
 			// Tell it to make a realpath
 			r->cwd = au->le->cwd;
-                        return nvlist_interp_cur_val(r, au->escape_mode);
+                        return nvlist_interp_cur_val((auparse_state_t *)au, r,
+                                                au->escape_mode);
 		}
         }
 	return NULL;
@@ -2233,7 +2234,8 @@ static const char *auparse_interpret_sock_parts(auparse_state_t *au,
 		if (nvlist_get_cur_type(r) != AUPARSE_TYPE_SOCKADDR)
 			return NULL;
 		// Get interpretation
-		const char *val = nvlist_interp_cur_val(r, au->escape_mode);
+                const char *val = nvlist_interp_cur_val((auparse_state_t *)au,
+                                        r, au->escape_mode);
 		if (val == NULL)
 			return NULL;
 		// make a copy since we modify it

--- a/auparse/expression.c
+++ b/auparse/expression.c
@@ -992,7 +992,7 @@ eval_unsigned_value(rnode *record, const struct expr *expr, int *valid)
 	if (expr->virtual_field == 0) {
 		nvlist_first(&record->nv);
 		if (nvlist_find_name(&record->nv, expr->v.p.field.name) == 0)
-			return 0;
+               res = nvlist_interp_cur_val(au, record, au->escape_mode);
 		const char *val = nvlist_get_cur_val(&record->nv);
 		if (val) {
 			uint32_t v = strtoul(val, NULL, 10);

--- a/auparse/internal.h
+++ b/auparse/internal.h
@@ -28,6 +28,7 @@
 #include "data_buf.h"
 #include "normalize-llist.h"
 #include "dso.h"
+#include "nvlist.h"
 #include <stdio.h>
 
 /* This is what state the parser is in */
@@ -173,6 +174,7 @@ struct opaque
 	int au_ready;		// For speed, we note how many EBS_COMPLETE
 				// events we hold at any point in time. Thus
 				// we don't have to scan the list
+	nvlist interpretations;		// Per-parser interpretations list
 	auparse_esc_t escape_mode;
 	message_t message_mode;		// Where to send error messages
 	debug_message_t debug_message;	// Whether or not messages are debug or not

--- a/auparse/interpret.h
+++ b/auparse/interpret.h
@@ -32,12 +32,13 @@
 /* Make these hidden to prevent conflicts */
 AUDIT_HIDDEN_START
 
-void init_interpretation_list(void);
-int load_interpretation_list(const char *buf);
-void free_interpretation_list(void);
-unsigned int interpretation_list_cnt(void);
+void init_interpretation_list(auparse_state_t *au);
+int load_interpretation_list(auparse_state_t *au, const char *buf);
+void free_interpretation_list(auparse_state_t *au);
+unsigned int interpretation_list_cnt(const auparse_state_t *au);
 int lookup_type(const char *name);
-const char *do_interpret(rnode *r, auparse_esc_t escape_mode);
+const char *do_interpret(auparse_state_t *au, rnode *r,
+auparse_esc_t escape_mode);
 void _aulookup_destroy_uid_list(void);
 void aulookup_destroy_gid_list(void);
 void aulookup_metrics(unsigned int *uid, unsigned int *gid);

--- a/auparse/nvlist.c
+++ b/auparse/nvlist.c
@@ -137,7 +137,8 @@ int nvlist_get_cur_type(rnode *r)
 	return auparse_interp_adjust_type(r->type, node->name, node->val);
 }
 
-const char *nvlist_interp_cur_val(rnode *r, auparse_esc_t escape_mode)
+const char *nvlist_interp_cur_val(auparse_state_t *au, rnode *r,
+auparse_esc_t escape_mode)
 {
 	nvlist *l = &r->nv;
 	if (l->cnt == 0)
@@ -145,7 +146,7 @@ const char *nvlist_interp_cur_val(rnode *r, auparse_esc_t escape_mode)
 	nvnode *node = &l->array[l->cur];
 	if (node->interp_val)
 		return node->interp_val;
-	return do_interpret(r, escape_mode);
+       return do_interpret(au, r, escape_mode);
 }
 
 // This function determines if a chunk of memory is part of the parsed up

--- a/auparse/nvlist.h
+++ b/auparse/nvlist.h
@@ -48,7 +48,8 @@ void nvlist_create(nvlist *l);
 void nvlist_clear(nvlist *l, int free_interp);
 nvnode *nvlist_next(nvlist *l);
 int nvlist_get_cur_type(rnode *r);
-const char *nvlist_interp_cur_val(rnode *r, auparse_esc_t escape_mode);
+const char *nvlist_interp_cur_val(auparse_state_t *au, rnode *r,
+auparse_esc_t escape_mode);
 int nvlist_append(nvlist *l, const nvnode *node);
 void nvlist_interp_fixup(const nvlist *l);
 

--- a/src/auditctl-listing.c
+++ b/src/auditctl-listing.c
@@ -40,6 +40,7 @@
 /* Global vars */
 static llist l;
 static int printed;
+static auparse_state_t interp_au;
 extern int list_requested, interpret;
 extern char key[AUDIT_MAX_KEY_LEN+1];
 extern const char key_sep[2];
@@ -466,9 +467,9 @@ static void print_rule(const struct audit_rule_data *r)
 					id.val = val;
 					type = auparse_interp_adjust_type(
 						AUDIT_SYSCALL, name, val);
-					out = auparse_do_interpretation(type,
-							&id,
-							AUPARSE_ESC_TTY);
+                                       out = auparse_do_interpretation(&interp_au,
+                                                       type, &id,
+                                                       AUPARSE_ESC_TTY);
 					printf(" -F %s%s%s", name,
 						audit_operator_to_symbol(op),
 								out);
@@ -564,7 +565,13 @@ static const char *get_failure(unsigned f)
  */
 int audit_print_reply(const struct audit_reply *rep, int fd)
 {
-	_audit_elf = 0;
+       static int init_done = 0;
+       if (!init_done) {
+               memset(&interp_au, 0, sizeof(interp_au));
+               init_interpretation_list(&interp_au);
+               init_done = 1;
+       }
+       _audit_elf = 0;
 
 	switch (rep->type) {
 		case NLMSG_NOOP:

--- a/src/ausearch-parse.c
+++ b/src/ausearch-parse.c
@@ -209,10 +209,19 @@ int extract_search_items(llist *l)
  */
 static nvlist uid_nvl;
 static int uid_list_created=0;
+static auparse_state_t interp_au;
+static int interp_init = 0;
 static const char *lookup_uid(const char *field, uid_t uid)
 {
-	const char *value;
-	value = _auparse_lookup_interpretation(field);
+       const char *value;
+
+       if (!interp_init) {
+               memset(&interp_au, 0, sizeof(interp_au));
+               init_interpretation_list(&interp_au);
+               interp_init = 1;
+       }
+
+       value = _auparse_lookup_interpretation(&interp_au, field);
 	if (value)
 		return value;
 	if (uid == 0)

--- a/src/ausearch-report.c
+++ b/src/ausearch-report.c
@@ -61,18 +61,18 @@ static int loaded = 0;
 
 void ausearch_load_interpretations(const lnode *n)
 {
-	if (loaded == 0) {
-		_auparse_load_interpretations(n->interp);
-		loaded = 1;
-	}
+       if (loaded == 0) {
+               _auparse_load_interpretations(au, n->interp);
+               loaded = 1;
+       }
 }
 
 void ausearch_free_interpretations(void)
 {
-	if (loaded) {
-		_auparse_free_interpretations();
-		loaded = 0;
-	}
+       if (loaded) {
+               _auparse_free_interpretations(au);
+               loaded = 0;
+       }
 }
 
 /* This function branches to the correct output format */
@@ -382,7 +382,7 @@ static void report_interpret(char *name, char *val, int comma, int rtype)
 	id.val = val;
 	id.cwd = NULL;
 
-	char *out = auparse_do_interpretation(type, &id, escape_mode);
+       char *out = auparse_do_interpretation(au, type, &id, escape_mode);
 	if (type == AUPARSE_TYPE_UNCLASSIFIED)
 		printf("%s%c", val, comma ? ',' : ' ');
 	else if (name[0] == 'k' && strcmp(name, "key") == 0) {


### PR DESCRIPTION
## Summary
- move interpretation list into `auparse_state_t`
- update internal APIs to pass `auparse_state_t*`
- adjust tools to use new interfaces
- initialize temporary parse state where needed

## Testing
- `autoreconf -v --install` *(fails: command not found)*