### PR TITLE
Fix filename retrieval in Python auparse init

### DIFF
--- a/bindings/python/auparse_python.c
+++ b/bindings/python/auparse_python.c
@@ -467,10 +467,22 @@ AuParser_init(AuParser *self, PyObject *args, PyObject *kwds)
 	int fd = fileno(fp);
 	fp = fdopen(fd, "r");
 #endif
+        const char *filename = NULL;
+#if PY_MAJOR_VERSION < 3
+        /* PyFile_Name is available in Python 2 */
+        filename = PYSTR_ASSTRING(PyFile_Name(source));
+#else
+        /* In Python 3 obtain the name attribute if possible */
+        PyObject *name_obj = PyObject_GetAttrString(source, "name");
+        if (name_obj && PYSTR_CHECK(name_obj))
+            filename = PYSTR_ASSTRING(name_obj);
+        Py_XDECREF(name_obj);
+#endif
         if ((self->au = auparse_init(source_type, fp)) == NULL) {
-            //char *filename = PYSTR_ASSTRING(PyFile_Name(source));
-            char *filename = "TODO";
-            PyErr_SetFromErrnoWithFilename(PyExc_IOError, filename);
+            if (filename)
+                PyErr_SetFromErrnoWithFilename(PyExc_IOError, filename);
+            else
+                PyErr_SetFromErrno(PyExc_IOError);
             return -1;
         }
     } break;


### PR DESCRIPTION
## Summary
- handle filename lookup for AUSOURCE_FILE_POINTER in Python bindings

## Testing
- `python3 -m py_compile auparse/test/auparse_test.py`
- `python3 auparse/test/auparse_test.py` *(fails: ModuleNotFoundError)*