### PR TITLE
Add Fedora CI for build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Build and Test
+
+on:
+  pull_request:
+  push:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - name: Install build dependencies
+        run: |
+          dnf -y update && dnf -y install \
+            make gcc kernel-headers systemd \
+            autoconf automake libtool \
+            libcap-ng-devel krb5-devel \
+            python3-devel python-unversioned-command swig \
+            openldap-devel
+          dnf clean all
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Prepare build
+        run: |
+          autoreconf -fv --install
+          ./configure --with-python3=yes --enable-gssapi-krb5=yes \
+            --with-arm --with-aarch64 --with-libcap-ng=yes \
+            --without-golang --with-io_uring
+      - name: Build
+        run: make -j$(nproc)
+      - name: Run tests
+        run: make check

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ make install
 
 If you are packaging this, you probably want to do "make dist" instead and use the resulting tar file with your package building framework. A spec file is included in the git repo as an example of packaging it using rpm. This spec file is not known to be the official spec file used by any distribution. It's just an example.
 
+CONTINUOUS INTEGRATION
+----------------------
+Pull requests are automatically built and tested using a Fedora-based GitHub Actions workflow. The job installs the dependencies listed in `audit.spec`, runs `autoreconf`, configures the project, and executes `make check` to ensure changes compile and pass the test suite.
+
+
 CROSS COMPILING
 ---------------
 Cross compiling is not officially supported. There have been people that have submitted patches to make it work. But it is not documented how to make it work. It is likely that you have to somehow override CC, CXX, RANLIB, AR, LD, and NM when running configure to pickup the cross compiler, linker, archive, etc. If you have patches that fix any problems, they will be merged. If you have suggestions for how to improve cross compiling documentation, file an issue stating how to improve instructions.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds on Fedora
- describe the workflow in README

## Testing
- `autoreconf -f --install` *(fails: command not found)*