### PR TITLE
Fix allocation failure in list_append

### DIFF
--- a/src/auditctl-llist.c
+++ b/src/auditctl-llist.c
@@ -67,13 +67,17 @@ int list_append(llist *l, const struct audit_rule_data *r, size_t sz)
 	if (newnode == NULL)
 		return 1;
 
-	if (r) {
-		void *rr = malloc(sz);
-		if (rr)
-			memcpy(rr, r, sz);
-		newnode->r = rr;
-	} else
-		newnode->r = NULL;
+       if (r) {
+               void *rr = malloc(sz);
+               if (rr == NULL) {
+                       free(newnode);
+                       return 1;
+               }
+               memcpy(rr, r, sz);
+               newnode->r = rr;
+       } else {
+               newnode->r = NULL;
+       }
 
 	newnode->size = sz;
 	newnode->next = 0;


### PR DESCRIPTION
## Summary
- handle failed malloc when appending to rule list

## Testing
- `gcc -c -Isrc src/auditctl-llist.c -o /tmp/auditctl-llist.o`